### PR TITLE
Add an ANSI formatter for output on the console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+*.bak
 *.swp
 *.kate-swp
 /cache/

--- a/src/formatters/ansiformatter.class.php
+++ b/src/formatters/ansiformatter.class.php
@@ -1,0 +1,105 @@
+<?php
+/// @cond ALL
+require_once(dirname(__FILE__) . '/../utils/cssparser.class.php');
+
+/**
+ * ANSI output formatter for Luminous.
+ */
+class LuminousFormatterAnsi extends LuminousFormatter {
+
+  private $css = null;
+
+  function __construct() { }
+
+  function set_theme($theme) {
+    $this->css = new LuminousCSSParser();
+    $this->css->convert($theme);
+  }
+
+  /// Converts a hexadecimal string in the form #ABCDEF to an RGB array
+  static function hex2rgb($hex) {
+    $x = hexdec(substr($hex, 1));
+    $b = $x % 256;
+    $g = ($x >> 8) % 256;
+    $r = ($x >> 16) % 256;
+
+    $rgb = array($r, $g, $b);
+    return $rgb;
+  }
+
+  protected function linkify($src) {
+    return $src;
+  }
+
+  function insert_escape_sequences($matches) {
+    $match = strtolower($matches[1]);
+    $rules = $this->css->rules();
+    $esc_seq = '';
+
+    if (isset($rules[$match])) {
+      if ($this->css->value($match, 'bold', false) === true)
+        $esc_seq .= "\033[1m";
+      if ($this->css->value($match, 'italic', false) === true)
+        $esc_seq .= "\033[3m";
+      if ($this->css->value($match, 'underline', false) === true)
+        $esc_seq .= "\033[4m";
+      if ($this->css->value($match, 'strikethrough', false) === true)
+        $esc_seq .= "\033[9m";
+      if (($color = $this->css->value($match, 'color', null)) !== null) {
+        if (preg_match('/^#[a-f0-9]{6}$/i', $color))  {
+          $esc_seq .= "\033[38;2;" . implode(';', self::hex2rgb($color)) . 'm';
+        }
+      }
+      if (($bgcolor = $this->css->value($match, 'bgcolor', null)) !== null) {
+        if (preg_match('/^#[a-f0-9]{6}$/i', $bgcolor))  {
+          $esc_seq .= "\033[48;2;" . implode(';', self::hex2rgb($bgcolor)) . 'm';
+        }
+      }
+    }
+
+    return $esc_seq;
+  }
+
+  function format($str) {
+    if ($this->css === null)
+      throw new Exception('ANSI formatter has not been set a theme');
+    $out = '';
+
+    $s = '';
+    $str = preg_replace('%<([^/>]+)>\s*</\\1>%', '', $str);
+    $str = str_replace("\t", '  ', $str);
+
+    $lines = explode("\n", $str);
+
+    if ($this->wrap_length > 0)  {
+      $str = '';
+      foreach($lines as $i=>$l) {
+        $this->wrap_line($l, $this->wrap_length);
+        $str .= $l;
+      }
+    }
+
+    $str_ = preg_split('/(<[^>]+>)/', $str, -1,
+      PREG_SPLIT_DELIM_CAPTURE|PREG_SPLIT_NO_EMPTY);
+
+    foreach($str_ as $s_) {
+      if ($s_[0] === '<') {
+        $s_ = preg_replace('%</[^>]+>%', "\033[0m", $s_);
+        $s_ = preg_replace_callback('%<([^>]+)>%', array($this, 'insert_escape_sequences'), $s_);
+      } else {
+        $s_ = str_replace('&gt;', '>', $s_);
+        $s_ = str_replace('&lt;', '<', $s_);
+        $s_ = str_replace('&amp;', '&', $s_);
+      }
+
+      $s .= $s_;
+    }
+
+    unset($str_);
+
+    $out .= $s;
+    return $out;
+  }
+
+}
+/// @endcond

--- a/src/luminous.php
+++ b/src/luminous.php
@@ -37,9 +37,9 @@ define('LUMINOUS_VERSION', 'master');
  *
  * In fact, it is used by (at least) the diff scanner, which uses its
  * scanner table.
- * 
+ *
  * @internal
- * 
+ *
  */
 class _Luminous {
 
@@ -50,11 +50,11 @@ class _Luminous {
   public $scanners; ///< the scanner table
 
   public $cache = null;
-  
+
   /**
    * The language is passed to the formatter which may choose to do something
    * interesting with it. If you use the scanners table this can be figured out
-   * automatically, but if you pass in your own scanner, you will need to 
+   * automatically, but if you pass in your own scanner, you will need to
    * give a language name if you want the formatter to consider it.
    */
   public $language = null;
@@ -93,11 +93,14 @@ class _Luminous {
     } elseif($fmt === 'latex') {
       require_once($fmt_path . 'latexformatter.class.php');
       $formatter = new LuminousFormatterLatex();
+    } elseif($fmt === 'ansi') {
+      require_once($fmt_path . 'ansiformatter.class.php');
+      $formatter = new LuminousFormatterAnsi();
     } elseif($fmt ===  null || $fmt === 'none') {
       require_once($fmt_path . 'identityformatter.class.php');
       $formatter = new LuminousIdentityFormatter();
     }
-    
+
     if ($formatter === null) {
       throw new Exception('Unknown formatter: ' . $this->settings->format);
       return null;
@@ -149,7 +152,7 @@ class _Luminous {
   }
 
 
-  
+
   /**
    * The real highlighting function
    * @throw InvalidArgumentException if $scanner is not either a string or a
@@ -170,7 +173,7 @@ class _Luminous {
     $this->cache = null;
     if (!is_string($source)) throw new InvalidArgumentException('Non-string '
         . 'supplied for $source');
-    
+
     if (!($scanner instanceof LuminousScanner)) {
       if (!is_string($scanner)) throw new InvalidArgumentException('Non-string
         or LuminousScanner instance supplied for $scanner');
@@ -231,7 +234,7 @@ abstract class luminous {
 
   /**
    * @brief Highlights a string according to the current settings
-   * 
+   *
    * @param $scanner The scanner to use, this can either be a langauge code,
    *    or it can be an instance of LuminousScanner.
    * @param $source The source string
@@ -280,13 +283,13 @@ abstract class luminous {
 
   /**
    * @brief Highlights a file according to the current setings.
-   * 
+   *
    * @param $scanner The scanner to use, this can either be a langauge code,
    *    or it can be an instance of LuminousScanner.
    * @param $file the source string
    * @param $cache Whether or not to use the cache
    * @return the highlighted source code.
-   * 
+   *
    * To specify different output formats or other options, see set().
    */
   static function highlight_file($scanner, $file, $cache_or_settings=null) {
@@ -308,11 +311,11 @@ abstract class luminous {
 
   /**
    * @brief Registers a scanner
-   * 
+   *
    * Registers a scanner with Luminous's scanner table. Utilising this
    * function means that Luminous will handle instantiation and inclusion of
    * the scanner's source file in a lazy-manner.
-   * 
+   *
    * @param $language_code A string or array of strings designating the
    *    aliases by which this scanner may be accessed
    * @param $classname The class name of the scanner, as string. If you
@@ -331,7 +334,7 @@ abstract class luminous {
       $luminous_->scanners->AddScanner($language_code, $classname,
         $readable_language, $path, $dependencies);
   }
-  
+
   /**
    * @brief Get the full filesystem path to Luminous
    * @return what Luminous thinks its location is on the filesystem
@@ -343,7 +346,7 @@ abstract class luminous {
 
   /**
    * @brief Gets a list of installed themes
-   * 
+   *
    * @return the list of theme files present in style/.
    * Each theme will simply be a filename, and will end in .css, and will not
    * have any directory prefix.
@@ -374,13 +377,13 @@ abstract class luminous {
   static function theme_exists($theme) {
     return in_array($theme, self::themes());
   }
-  
+
   /**
    * @brief Reads a CSS theme file
    * Gets the CSS-string content of a theme file.
    * Use this function for reading themes as it involves security
    * checks against reading arbitrary files
-   * 
+   *
    * @param $theme The name of the theme to retrieve, which may or may not
    *    include the .css suffix.
    * @return the content of a theme; this is the actual CSS text.
@@ -388,14 +391,14 @@ abstract class luminous {
    */
   static function theme($theme) {
     if (!preg_match('/\.css$/i', $theme)) $theme .= '.css';
-    if (self::theme_exists($theme)) 
+    if (self::theme_exists($theme))
       return file_get_contents(self::root() . "/style/" . $theme);
     else
       throw new Exception('No such theme file: ' . $theme);
   }
 
 
-  
+
   /**
    * @brief Gets a setting's value
    * @param $option The name of the setting (corresponds to an attribute name
@@ -428,26 +431,26 @@ abstract class luminous {
    *
    * Options are stored in LuminousOptions, which provides documentation of
    * each option.
-   * 
+   *
    * @note as of 0.7 this is a thin wrapper around LuminousOptions::set()
-   * 
+   *
    * @see LuminousOptions::set
    */
   static function set($option, $value=null) {
     global $luminous_;
     $luminous_->settings->set($option, $value);
-  }  
+  }
 
   /**
    * @brief Gets a list of registered scanners
-   * 
+   *
    * @return a list of scanners currently registered. The list is in the
    * format:
-   * 
+   *
    *    language_name => codes,
-   * 
-   * where language_name is a string, and codes is an array of strings. 
-   * 
+   *
+   * where language_name is a string, and codes is an array of strings.
+   *
    * The array is sorted alphabetically by key.
    */
   static function scanners() {
@@ -459,7 +462,7 @@ abstract class luminous {
 
   /**
    * @brief Gets a formatter instance
-   * 
+   *
    * @return an instance of a LuminousFormatter according to the current
    * format setting
    *
@@ -489,13 +492,13 @@ abstract class luminous {
    * @brief Attempts to guess the language of a piece of source code
    * @param $src The source code whose language is to be guessed
    * @param $confidence The desired confidence level: if this is 0.05 but the
-   *  best guess has a confidence of 0.04, then $default is returned. Note 
+   *  best guess has a confidence of 0.04, then $default is returned. Note
    *  that the confidence level returned by scanners is quite arbitrary, so
-   *  don't set this to '1' thinking that'll give you better results. 
+   *  don't set this to '1' thinking that'll give you better results.
    *  A realistic confidence is likely to be quite low, because a scanner will
    *  only return 1 if it's able to pick out a shebang (#!) line or something
-   *  else definitive. If there exists no such identifier, a 'strong' 
-   *  confidence which is right most of the time might be as low as 0.1. 
+   *  else definitive. If there exists no such identifier, a 'strong'
+   *  confidence which is right most of the time might be as low as 0.1.
    *  Therefore it is recommended to keep this between 0.01 and 0.10.
    * @param $default The default name to return in the event that no scanner
    * thinks this source belongs to them (at the desired confidence).
@@ -506,9 +509,9 @@ abstract class luminous {
    */
   static function guess_language($src, $confidence=0.05, $default = 'plain') {
     $guess = self::guess_language_full($src);
-    if ($guess[0]['p'] >= $confidence) 
+    if ($guess[0]['p'] >= $confidence)
       return $guess[0]['codes'][0];
-    else 
+    else
       return $default;
   }
 
@@ -517,12 +520,12 @@ abstract class luminous {
    * @param $src The source code whose language is to be guessed
    * @return An array - the array is ordered by probability, with the most
    *    probable language coming first in the array.
-   *    Each array element is an array which represents a language (scanner), 
+   *    Each array element is an array which represents a language (scanner),
    *    and has the keys:
    *    \li \c 'language' => Human-readable language description,
    *    \li \c 'codes' => valid codes for the language (array),
    *    \li \c 'p' => the probability (between 0.0 and 1.0 inclusive),
-   * 
+   *
    * note that \c 'language' and \c 'codes' are the key => value pair from
    * luminous::scanners()
    *
@@ -536,13 +539,13 @@ abstract class luminous {
    * $guesses = luminous::guess_language($src);
    * $output = luminous::highlight($guesses[0]['codes'][0], $src);
    * @endcode
-   * 
-   * @see luminous::guess_language 
+   *
+   * @see luminous::guess_language
    */
   static function guess_language_full($src) {
     global $luminous_;
     // first we're going to make an 'info' array for the source, which
-    // precomputes some frequently useful things, like how many lines it 
+    // precomputes some frequently useful things, like how many lines it
     // has, etc. It prevents scanners from redundantly figuring these things
     // out themselves
     $lines = preg_split("/\r\n|[\r\n]/", $src);
@@ -588,13 +591,13 @@ abstract class luminous {
   static function head_html() {
     global $luminous_;
     $theme = self::setting('theme');
-    $relative_root = self::setting('relative-root'); 
+    $relative_root = self::setting('relative-root');
     $js = self::setting('include-javascript');
     $jquery = self::setting('include-jquery');
-    
+
     if (!preg_match('/\.css$/i', $theme)) $theme .= '.css';
     if (!self::theme_exists($theme)) $theme = 'luminous_light.css';
-    
+
     if ($relative_root === null) {
       $relative_root = str_replace($_SERVER['DOCUMENT_ROOT'], '/',
         dirname(__FILE__));
@@ -622,5 +625,5 @@ abstract class luminous {
   }
 }
 
-/// @endcond 
+/// @endcond
 // ends user

--- a/src/options.class.php
+++ b/src/options.class.php
@@ -19,15 +19,15 @@
  * replaced with dashed in the call.
  */
 class LuminousOptions {
-    
+
   /**
    * @brief Whether to use the built-in cache
    */
   private $cache = true;
-  
+
   /**
    * @brief Maximum age of cache files in seconds
-   * 
+   *
    * Cache files which have not been read for this length of time will be
    * removed from the file system. The file's 'mtime' is used to calculate
    * when it was last used, and a cache hit triggers a 'touch'
@@ -59,8 +59,8 @@ class LuminousOptions {
    * of the first line
    */
   private $start_line = 1;
-  
-  
+
+
   /**
     * @brief Highlighting of lines
     *
@@ -182,13 +182,13 @@ class LuminousOptions {
 
   private $verbose = true;
 
-  
+
   public function LuminousOptions($opts=null) {
     if (is_array($opts)) {
       $this->set($opts);
     }
   }
-  
+
   public function set($nameOrArray, $value=null) {
     $array = $nameOrArray;
     if (!is_array($array)) {
@@ -200,7 +200,7 @@ class LuminousOptions {
       $this->__set($option, $value);
     }
   }
-  
+
 
   private static function check_type($value, $type, $nullable=false) {
     if ($nullable && $value === null) return true;
@@ -249,17 +249,17 @@ class LuminousOptions {
      elseif($name === 'html_strict') {
       if (self::check_type($value, 'bool')) $this->$name = $value;
     }
-    elseif($name === 'include_javascript' || $name === 'include_jquery') 
+    elseif($name === 'include_javascript' || $name === 'include_jquery')
       $this->set_bool($name, $value);
-    elseif($name === 'line_numbers') 
+    elseif($name === 'line_numbers')
       $this->set_bool($name, $value);
-    elseif($name === 'start_line') 
+    elseif($name === 'start_line')
       $this->set_start_line($value);
     elseif($name === 'highlight_lines') {
       if (self::check_type($value, 'array'))
         $this->highlight_lines = $value;
     }
-    elseif($name === 'max_height') 
+    elseif($name === 'max_height')
       $this->set_height($value);
     elseif($name === 'relative_root') {
       if (self::check_type($value, 'string', true)) $this->$name = $value;
@@ -290,7 +290,7 @@ class LuminousOptions {
       $this->$key = $value;
     }
   }
-  
+
   private function set_start_line($value) {
       if (is_numeric($value) && $value > 0) {
           $this->start_line = $value;
@@ -305,7 +305,7 @@ class LuminousOptions {
     if($is_obj || self::check_type($value, 'string', true)) {
       // validate the string is a known type
       if (!$is_obj && !in_array($value, array('html', 'html-full',
-        'html-inline', 'latex', 'none', null), true)) {
+        'html-inline', 'latex', 'ansi', 'none', null), true)) {
         throw new Exception('Invalid formatter: ' . $value);
       }
       else {
@@ -328,7 +328,7 @@ class LuminousOptions {
   private function set_height($value) {
     // height should be either a number or a numeric string with some units at
     // the end
-    if (is_numeric($value) 
+    if (is_numeric($value)
       || (is_string($value) && preg_match('/^\d+/', $value))
     ) {
       $this->max_height = $value;


### PR DESCRIPTION
To use the ANSI formatter, the 'format' option has to be set to 'ansi'

See it in action at https://bit.ly/luminous-ansi-demo

Features:
- Based on the LaTeX formatter (well, that’s not a feature, but I think it’s worth mentioning)
- Support for XTerm 256 colors both as text color and as background color
- Support for bold, italic, underline, and strikethrough

Known issues which will be fixed when the conversion to PSR (#31) is finished:
- line numbers are not yet supported
- Nested tokens (like escape sequences inside strings) are not yet supported.
