### PR TITLE
Fix language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/regression/*/* linguist-vendored


### PR DESCRIPTION
I just happened to notice the GitHub language statistics were messed-up due to the files for the regression tests, and I decided to fix it.
